### PR TITLE
Improved smoke test quality across all SDKs

### DIFF
--- a/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/karma.conf.js
+++ b/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/karma.conf.js
@@ -19,7 +19,8 @@ module.exports = function (config) {
         // for example, you can disable the random execution with `random: false`
         // or set a specific seed with `seed: 4321`
       },
-      clearContext: false // leave Jasmine Spec Runner output visible in browser
+      clearContext: false, // leave Jasmine Spec Runner output visible in browser
+      smokeAppKey: process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND || ''
     },
     jasmineHtmlReporter: {
       suppressAll: true // removes the duplicated traces

--- a/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/src/lib/smoke-ws.spec.ts
+++ b/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/src/lib/smoke-ws.spec.ts
@@ -1,10 +1,19 @@
 import WebSocket from 'ws';
 
-const appKey = (globalThis as any).__karma__?.config?.smokeAppKey || '';
+describe('WebSocket smoke test', () => {
+  let appKey: string;
 
-(appKey ? describe : xdescribe)('WebSocket smoke test', () => {
+  beforeAll(() => {
+    appKey = (globalThis as any).__karma__?.config?.smokeAppKey || '';
+  });
+
   it('connects and receives initial definitions message', async () => {
-    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey!}/ws`);
+    if (!appKey) {
+      pending('TOGGLY_SMOKE_APP_KEY_FRONTEND not configured');
+      return;
+    }
+
+    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey}/ws`);
 
     const message = await new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {

--- a/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/src/lib/smoke-ws.spec.ts
+++ b/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/src/lib/smoke-ws.spec.ts
@@ -1,6 +1,6 @@
 import WebSocket from 'ws';
 
-const appKey = (globalThis as any).process?.env?.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = (globalThis as any).__karma__?.config?.smokeAppKey || '';
 
 (appKey ? describe : xdescribe)('WebSocket smoke test', () => {
   it('connects and receives initial definitions message', async () => {

--- a/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/src/lib/smoke-ws.spec.ts
+++ b/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/src/lib/smoke-ws.spec.ts
@@ -1,5 +1,3 @@
-import WebSocket from 'ws';
-
 describe('WebSocket smoke test', () => {
   let appKey: string;
 
@@ -21,19 +19,19 @@ describe('WebSocket smoke test', () => {
         reject(new Error('WebSocket timed out after 15 seconds'));
       }, 15_000);
 
-      ws.on('message', (data: Buffer) => {
-        const text = data.toString();
+      ws.onmessage = (event: MessageEvent) => {
+        const text = typeof event.data === 'string' ? event.data : '';
         try {
           const msg = JSON.parse(text);
           if (msg.type === 'ping') return;
         } catch { /* not JSON, resolve anyway */ }
         clearTimeout(timeout);
         resolve(text);
-      });
-      ws.on('error', (err: Error) => {
+      };
+      ws.onerror = () => {
         clearTimeout(timeout);
-        reject(err);
-      });
+        reject(new Error('WebSocket error'));
+      };
     });
 
     const parsed = JSON.parse(message);

--- a/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/src/lib/smoke-ws.spec.ts
+++ b/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/src/lib/smoke-ws.spec.ts
@@ -1,14 +1,10 @@
 import WebSocket from 'ws';
 
-describe('WebSocket smoke test', () => {
-  const appKey = (globalThis as any).process?.env?.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = (globalThis as any).process?.env?.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+(appKey ? describe : xdescribe)('WebSocket smoke test', () => {
   it('connects and receives initial definitions message', async () => {
-    if (!appKey) {
-      return;
-    }
-
-    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey}/ws`);
+    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey!}/ws`);
 
     const message = await new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {

--- a/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/src/lib/smoke.spec.ts
+++ b/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/src/lib/smoke.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { NgxFeatureFlagsTogglyModule } from './ngx-feature-flags-toggly.module';
 import { TogglyService } from './toggly.service';
 
-const appKey = (globalThis as any).process?.env?.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = (globalThis as any).__karma__?.config?.smokeAppKey || '';
 
 (appKey ? describe : xdescribe)('Smoke test', () => {
   it('loads live evaluated flags', async () => {

--- a/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/src/lib/smoke.spec.ts
+++ b/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/src/lib/smoke.spec.ts
@@ -2,14 +2,10 @@ import { TestBed } from '@angular/core/testing';
 import { NgxFeatureFlagsTogglyModule } from './ngx-feature-flags-toggly.module';
 import { TogglyService } from './toggly.service';
 
-describe('Smoke test', () => {
-  const appKey = (globalThis as any).process?.env?.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = (globalThis as any).process?.env?.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+(appKey ? describe : xdescribe)('Smoke test', () => {
   it('loads live evaluated flags', async () => {
-    if (!appKey) {
-      return;
-    }
-
     TestBed.configureTestingModule({
       imports: [NgxFeatureFlagsTogglyModule.forRoot({
         appKey,

--- a/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/src/lib/smoke.spec.ts
+++ b/Toggly.FeatureManagement.Angular/projects/ngx-feature-flags-toggly/src/lib/smoke.spec.ts
@@ -2,10 +2,19 @@ import { TestBed } from '@angular/core/testing';
 import { NgxFeatureFlagsTogglyModule } from './ngx-feature-flags-toggly.module';
 import { TogglyService } from './toggly.service';
 
-const appKey = (globalThis as any).__karma__?.config?.smokeAppKey || '';
+describe('Smoke test', () => {
+  let appKey: string;
 
-(appKey ? describe : xdescribe)('Smoke test', () => {
+  beforeAll(() => {
+    appKey = (globalThis as any).__karma__?.config?.smokeAppKey || '';
+  });
+
   it('loads live evaluated flags', async () => {
+    if (!appKey) {
+      pending('TOGGLY_SMOKE_APP_KEY_FRONTEND not configured');
+      return;
+    }
+
     TestBed.configureTestingModule({
       imports: [NgxFeatureFlagsTogglyModule.forRoot({
         appKey,

--- a/Toggly.FeatureManagement.Astro/src/__tests__/smoke-ws.spec.ts
+++ b/Toggly.FeatureManagement.Astro/src/__tests__/smoke-ws.spec.ts
@@ -2,15 +2,11 @@
 import { describe, it, expect } from 'vitest';
 import WebSocket from 'ws';
 
-describe('WebSocket smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+describe.skipIf(!appKey)('WebSocket smoke test', () => {
   it('connects and receives initial definitions message', async () => {
-    if (!appKey) {
-      return;
-    }
-
-    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey}/ws`);
+    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey!}/ws`);
 
     const message = await new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {

--- a/Toggly.FeatureManagement.Astro/src/__tests__/smoke.spec.ts
+++ b/Toggly.FeatureManagement.Astro/src/__tests__/smoke.spec.ts
@@ -2,20 +2,16 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { initTogglyClient, $flags, __resetClient } from '../client/store.js';
 
-describe('Smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+describe.skipIf(!appKey)('Smoke test', () => {
   beforeEach(() => {
     __resetClient();
   });
 
   it('loads live evaluated flags', async () => {
-    if (!appKey) {
-      return;
-    }
-
     await initTogglyClient({
-      appKey,
+      appKey: appKey!,
       environment: 'Production',
       baseURI: 'https://definitions.toggly.io',
       featureFlagsRefreshInterval: 0,

--- a/Toggly.FeatureManagement.Javascript/feature_flags_toggly/spec/smoke-ws.test.ts
+++ b/Toggly.FeatureManagement.Javascript/feature_flags_toggly/spec/smoke-ws.test.ts
@@ -1,14 +1,10 @@
 import WebSocket = require('ws');
 
-describe('WebSocket smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+(appKey ? describe : describe.skip)('WebSocket smoke test', () => {
   it('connects and receives initial definitions message', async () => {
-    if (!appKey) {
-      return;
-    }
-
-    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey}/ws`);
+    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey!}/ws`);
 
     const message = await new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {

--- a/Toggly.FeatureManagement.Javascript/feature_flags_toggly/spec/smoke.test.ts
+++ b/Toggly.FeatureManagement.Javascript/feature_flags_toggly/spec/smoke.test.ts
@@ -1,15 +1,11 @@
 import { Toggly } from '../lib/toggly';
 
-describe('Smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+(appKey ? describe : describe.skip)('Smoke test', () => {
   beforeAll(async () => {
-    if (!appKey) {
-      return;
-    }
-
     await Toggly.init({
-      appKey,
+      appKey: appKey!,
       environment: 'Production',
       baseURI: 'https://definitions.toggly.io',
       featureFlagsRefreshInterval: 0,
@@ -21,10 +17,6 @@ describe('Smoke test', () => {
   });
 
   test('loads live evaluated flags', () => {
-    if (!appKey) {
-      return;
-    }
-
     expect(Toggly.isFeatureOn('FlagOn')).toBe(true);
     expect(Toggly.isFeatureOff('FlagOff')).toBe(true);
   });

--- a/Toggly.FeatureManagement.Next/nextjs-toggly-core/tests/smoke-ws.test.ts
+++ b/Toggly.FeatureManagement.Next/nextjs-toggly-core/tests/smoke-ws.test.ts
@@ -7,15 +7,11 @@
 import { describe, it, expect } from 'vitest';
 import WebSocket from 'ws';
 
-describe('WebSocket smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+describe.skipIf(!appKey)('WebSocket smoke test', () => {
   it('connects and receives initial definitions message', async () => {
-    if (!appKey) {
-      return;
-    }
-
-    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey}/ws`);
+    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey!}/ws`);
 
     const message = await new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {

--- a/Toggly.FeatureManagement.Next/nextjs-toggly-core/tests/smoke.test.ts
+++ b/Toggly.FeatureManagement.Next/nextjs-toggly-core/tests/smoke.test.ts
@@ -1,16 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { createTogglyClient } from '../src/client';
 
-describe('Smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+describe.skipIf(!appKey)('Smoke test', () => {
   it('loads live evaluated flags', async () => {
-    if (!appKey) {
-      return;
-    }
-
     const client = createTogglyClient({
-      appKey,
+      appKey: appKey!,
       environment: 'Production',
       baseUri: 'https://definitions.toggly.io',
       refreshInterval: 0,

--- a/Toggly.FeatureManagement.Node/toggly-node-core/tests/smoke-ws.test.ts
+++ b/Toggly.FeatureManagement.Node/toggly-node-core/tests/smoke-ws.test.ts
@@ -2,16 +2,12 @@
 import { describe, it, expect } from 'vitest';
 import { createTogglyClient } from '../src/client.js';
 
-describe('WebSocket smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_BACKEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_BACKEND;
 
+describe.skipIf(!appKey)('WebSocket smoke test', () => {
   it('connects via WebSocket and receives live updates', async () => {
-    if (!appKey) {
-      return;
-    }
-
     const client = createTogglyClient({
-      appKey,
+      appKey: appKey!,
       environment: 'Production',
       baseUrl: 'https://definitions.toggly.io',
       enableStreaming: true,

--- a/Toggly.FeatureManagement.Node/toggly-node-core/tests/smoke.test.ts
+++ b/Toggly.FeatureManagement.Node/toggly-node-core/tests/smoke.test.ts
@@ -1,16 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { createTogglyClient } from '../src/client.js';
 
-describe('Smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_BACKEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_BACKEND;
 
+describe.skipIf(!appKey)('Smoke test', () => {
   it('loads live evaluated flags', async () => {
-    if (!appKey) {
-      return;
-    }
-
     const client = createTogglyClient({
-      appKey,
+      appKey: appKey!,
       environment: 'Production',
       baseUrl: 'https://definitions.toggly.io',
       refreshInterval: 0,

--- a/Toggly.FeatureManagement.Nuxt/nuxt-toggly-core/tests/smoke-ws.test.ts
+++ b/Toggly.FeatureManagement.Nuxt/nuxt-toggly-core/tests/smoke-ws.test.ts
@@ -7,15 +7,11 @@
 import { describe, it, expect } from 'vitest';
 import WebSocket from 'ws';
 
-describe('WebSocket smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+describe.skipIf(!appKey)('WebSocket smoke test', () => {
   it('connects and receives initial definitions message', async () => {
-    if (!appKey) {
-      return;
-    }
-
-    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey}/ws`);
+    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey!}/ws`);
 
     const message = await new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {

--- a/Toggly.FeatureManagement.Nuxt/nuxt-toggly-core/tests/smoke.test.ts
+++ b/Toggly.FeatureManagement.Nuxt/nuxt-toggly-core/tests/smoke.test.ts
@@ -1,16 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { createTogglyClient } from '../src/client';
 
-describe('Smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+describe.skipIf(!appKey)('Smoke test', () => {
   it('loads live evaluated flags', async () => {
-    if (!appKey) {
-      return;
-    }
-
     const client = createTogglyClient({
-      appKey,
+      appKey: appKey!,
       environment: 'Production',
       baseUri: 'https://definitions.toggly.io',
       refreshInterval: 0,

--- a/Toggly.FeatureManagement.React/src/smoke-ws.spec.ts
+++ b/Toggly.FeatureManagement.React/src/smoke-ws.spec.ts
@@ -3,15 +3,11 @@
  */
 import WebSocket from 'ws';
 
-describe('WebSocket smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+(appKey ? describe : describe.skip)('WebSocket smoke test', () => {
   it('connects and receives initial definitions message', async () => {
-    if (!appKey) {
-      return;
-    }
-
-    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey}/ws`);
+    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey!}/ws`);
 
     const message = await new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {

--- a/Toggly.FeatureManagement.React/src/smoke.spec.ts
+++ b/Toggly.FeatureManagement.React/src/smoke.spec.ts
@@ -1,15 +1,11 @@
 import Toggly from './services/toggly.service';
 
-describe('Smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+(appKey ? describe : describe.skip)('Smoke test', () => {
   test('loads live evaluated flags', async () => {
-    if (!appKey) {
-      return;
-    }
-
     const service = new Toggly({
-      appKey,
+      appKey: appKey!,
       environment: 'Production',
       baseURI: 'https://definitions.toggly.io',
     });

--- a/Toggly.FeatureManagement.ReactNative/libs/core/jest.config.js
+++ b/Toggly.FeatureManagement.ReactNative/libs/core/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
     'src/**/*.ts',
     '!src/**/*.d.ts',
     '!src/**/index.ts',
+    '!src/models/types.ts',
   ],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
@@ -28,5 +29,6 @@ module.exports = {
     }],
   },
   coverageProvider: 'v8',
+  forceExit: true,
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
 };

--- a/Toggly.FeatureManagement.ReactNative/libs/core/tests/smoke-ws.test.ts
+++ b/Toggly.FeatureManagement.ReactNative/libs/core/tests/smoke-ws.test.ts
@@ -1,14 +1,10 @@
 import WebSocket from 'ws';
 
-describe('WebSocket smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+(appKey ? describe : describe.skip)('WebSocket smoke test', () => {
   it('connects and receives initial definitions message', async () => {
-    if (!appKey) {
-      return;
-    }
-
-    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey}/ws`);
+    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey!}/ws`);
 
     const message = await new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {

--- a/Toggly.FeatureManagement.ReactNative/libs/core/tests/smoke.test.ts
+++ b/Toggly.FeatureManagement.ReactNative/libs/core/tests/smoke.test.ts
@@ -36,21 +36,17 @@ const fetchViaHttps = (url: string): Promise<MockFetchResponse> =>
     req.on('error', reject);
   });
 
-describe('Smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+(appKey ? describe : describe.skip)('Smoke test', () => {
   it('loads live evaluated flags', async () => {
-    if (!appKey) {
-      return;
-    }
-
     const originalFetch = global.fetch;
     (global.fetch as unknown as jest.Mock).mockImplementation((url: string) =>
       fetchViaHttps(url)
     );
 
     const service = new TogglyService({
-      appKey,
+      appKey: appKey!,
       environment: 'Production',
       baseURI: 'https://definitions.toggly.io',
       refreshInterval: 0,

--- a/Toggly.FeatureManagement.Remix/remix-toggly-client/tests/smoke-ws.spec.ts
+++ b/Toggly.FeatureManagement.Remix/remix-toggly-client/tests/smoke-ws.spec.ts
@@ -3,15 +3,11 @@
  */
 import WebSocket from 'ws';
 
-describe('WebSocket smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+(appKey ? describe : describe.skip)('WebSocket smoke test', () => {
   it('connects and receives initial definitions message', async () => {
-    if (!appKey) {
-      return;
-    }
-
-    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey}/ws`);
+    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey!}/ws`);
 
     const message = await new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {

--- a/Toggly.FeatureManagement.Remix/remix-toggly-client/tests/smoke.spec.tsx
+++ b/Toggly.FeatureManagement.Remix/remix-toggly-client/tests/smoke.spec.tsx
@@ -38,15 +38,11 @@ function fetchLiveFlags(appKey: string): Promise<Record<string, boolean>> {
   });
 }
 
-describe('Smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+(appKey ? describe : describe.skip)('Smoke test', () => {
   it('evaluates live flags through client context', async () => {
-    if (!appKey) {
-      return;
-    }
-
-    const flags = await fetchLiveFlags(appKey);
+    const flags = await fetchLiveFlags(appKey!);
     const serverContext: ServerFeatureContext = {
       flags,
       appKey,

--- a/Toggly.FeatureManagement.Remix/remix-toggly-core/package.json
+++ b/Toggly.FeatureManagement.Remix/remix-toggly-core/package.json
@@ -18,7 +18,8 @@
   ],
   "scripts": {
     "build": "rollup -c",
-    "test": "jest --coverage",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit",

--- a/Toggly.FeatureManagement.Remix/remix-toggly-server/package.json
+++ b/Toggly.FeatureManagement.Remix/remix-toggly-server/package.json
@@ -18,7 +18,8 @@
   ],
   "scripts": {
     "build": "tsup",
-    "test": "jest --coverage",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc --noEmit",
     "lint": "tsc --noEmit",

--- a/Toggly.FeatureManagement.Remix/remix-toggly-server/tests/smoke-ws.spec.ts
+++ b/Toggly.FeatureManagement.Remix/remix-toggly-server/tests/smoke-ws.spec.ts
@@ -1,15 +1,11 @@
 import { TogglyServerClient } from '../src/client';
 
-describe('WebSocket smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+(appKey ? describe : describe.skip)('WebSocket smoke test', () => {
   it('connects via WebSocket and receives live updates', async () => {
-    if (!appKey) {
-      return;
-    }
-
     const client = new TogglyServerClient({
-      appKey,
+      appKey: appKey!,
       environment: 'Production',
       baseUrl: 'https://definitions.toggly.io',
       timeout: 15000,

--- a/Toggly.FeatureManagement.Remix/remix-toggly-server/tests/smoke.spec.ts
+++ b/Toggly.FeatureManagement.Remix/remix-toggly-server/tests/smoke.spec.ts
@@ -1,15 +1,11 @@
 import { TogglyServerClient } from '../src/client';
 
-describe('Smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+(appKey ? describe : describe.skip)('Smoke test', () => {
   it('loads live evaluated flags', async () => {
-    if (!appKey) {
-      return;
-    }
-
     const client = new TogglyServerClient({
-      appKey,
+      appKey: appKey!,
       environment: 'Production',
       baseUrl: 'https://definitions.toggly.io',
       timeout: 15000,

--- a/Toggly.FeatureManagement.Svelte/svelte-feature-flags-toggly/src/__tests__/smoke-ws.spec.ts
+++ b/Toggly.FeatureManagement.Svelte/svelte-feature-flags-toggly/src/__tests__/smoke-ws.spec.ts
@@ -2,15 +2,11 @@
 import { describe, it, expect } from 'vitest';
 import WebSocket from 'ws';
 
-describe('WebSocket smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+describe.skipIf(!appKey)('WebSocket smoke test', () => {
   it('connects and receives initial definitions message', async () => {
-    if (!appKey) {
-      return;
-    }
-
-    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey}/ws`);
+    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey!}/ws`);
 
     const message = await new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {

--- a/Toggly.FeatureManagement.Svelte/svelte-feature-flags-toggly/src/__tests__/smoke.spec.ts
+++ b/Toggly.FeatureManagement.Svelte/svelte-feature-flags-toggly/src/__tests__/smoke.spec.ts
@@ -1,16 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { Toggly } from '../services/toggly.service';
 
-describe('Smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+describe.skipIf(!appKey)('Smoke test', () => {
   it('loads live evaluated flags', async () => {
-    if (!appKey) {
-      return;
-    }
-
     const service = new Toggly({
-      appKey,
+      appKey: appKey!,
       environment: 'Production',
       baseURI: 'https://definitions.toggly.io',
       featureFlagsRefreshInterval: 0,

--- a/Toggly.FeatureManagement.Vue/vue-feature-flags-toggly/src/__tests__/smoke-ws.spec.ts
+++ b/Toggly.FeatureManagement.Vue/vue-feature-flags-toggly/src/__tests__/smoke-ws.spec.ts
@@ -2,15 +2,11 @@
 import { describe, it, expect } from 'vitest';
 import WebSocket from 'ws';
 
-describe('WebSocket smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+describe.skipIf(!appKey)('WebSocket smoke test', () => {
   it('connects and receives initial definitions message', async () => {
-    if (!appKey) {
-      return;
-    }
-
-    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey}/ws`);
+    const ws = new WebSocket(`wss://definitions.toggly.io/${appKey!}/ws`);
 
     const message = await new Promise<string>((resolve, reject) => {
       const timeout = setTimeout(() => {

--- a/Toggly.FeatureManagement.Vue/vue-feature-flags-toggly/src/__tests__/smoke.spec.ts
+++ b/Toggly.FeatureManagement.Vue/vue-feature-flags-toggly/src/__tests__/smoke.spec.ts
@@ -1,16 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { Toggly } from '../plugins/toggly.service';
 
-describe('Smoke test', () => {
-  const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
+const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
+describe.skipIf(!appKey)('Smoke test', () => {
   it('loads live evaluated flags', async () => {
-    if (!appKey) {
-      return;
-    }
-
     const service = new Toggly().init({
-      appKey,
+      appKey: appKey!,
       environment: 'Production',
       baseURI: 'https://definitions.toggly.io',
     });

--- a/toggly-docusaurus-edge-sdk/libs/docusaurus-plugin/smoke.mjs
+++ b/toggly-docusaurus-edge-sdk/libs/docusaurus-plugin/smoke.mjs
@@ -1,6 +1,7 @@
 const appKey = process.env.TOGGLY_SMOKE_APP_KEY_FRONTEND;
 
 if (!appKey) {
+  console.warn('SKIPPED: TOGGLY_SMOKE_APP_KEY_FRONTEND not configured');
   process.exit(0);
 }
 

--- a/toggly-rust/toggly/src/context.rs
+++ b/toggly-rust/toggly/src/context.rs
@@ -34,7 +34,7 @@ impl EvalContext {
 
     /// Check if the context has an identity.
     pub fn has_identity(&self) -> bool {
-        self.identity.as_ref().map_or(false, |id| !id.is_empty())
+        self.identity.as_ref().is_some_and(|id| !id.is_empty())
     }
 
     /// Get a trait value.

--- a/toggly-rust/toggly/tests/smoke.rs
+++ b/toggly-rust/toggly/tests/smoke.rs
@@ -7,7 +7,10 @@ const DEFINITIONS_URL: &str = "https://definitions.toggly.io/";
 async fn smoke_unsigned_definitions() -> toggly::Result<()> {
     let app_key = match std::env::var("TOGGLY_SMOKE_APP_KEY_BACKEND") {
         Ok(v) if !v.is_empty() => v,
-        _ => return Ok(()),
+        _ => {
+            eprintln!("SKIPPED: TOGGLY_SMOKE_APP_KEY_BACKEND not configured");
+            return Ok(());
+        }
     };
 
     let client = TogglyClient::builder()
@@ -33,7 +36,10 @@ async fn smoke_unsigned_definitions() -> toggly::Result<()> {
 async fn smoke_signed_definitions() -> toggly::Result<()> {
     let app_key = match std::env::var("TOGGLY_SMOKE_APP_KEY_BACKEND") {
         Ok(v) if !v.is_empty() => v,
-        _ => return Ok(()),
+        _ => {
+            eprintln!("SKIPPED: TOGGLY_SMOKE_APP_KEY_BACKEND not configured");
+            return Ok(());
+        }
     };
 
     let client = TogglyClient::builder()


### PR DESCRIPTION
## Summary
- Updated all SDK smoke tests to properly report **skipped** status when environment variables are missing, instead of silently passing with zero assertions
- Fixed several silently failing CI tests across multiple SDKs

### Smoke test skip visibility (26 files across 13 SDKs)
- **Jest** (React, JavaScript, ReactNative, Remix): `describe.skip` pattern
- **Jasmine/Karma** (Angular): `pending()` with message + Karma config env var injection
- **Vitest** (Node, Next, Nuxt, Svelte, Astro, Vue): `describe.skipIf(!appKey)` pattern
- **Rust**: `eprintln!("SKIPPED: ...")` message before early return
- **Docusaurus** (plain script): `console.warn` before `process.exit(0)`

### Silently failing CI fixes
- **Rust**: Fixed `clippy::unnecessary_map_or` lint error on beta toolchain (`map_or` → `is_some_and`)
- **Remix**: Added missing `test:coverage` script to `remix-toggly-core` and `remix-toggly-server` packages
- **React Native Core**: Excluded pure type definitions file from coverage calculation (was dragging coverage below 80% threshold), added `forceExit` to fix worker process hanging
- **Angular**: Fixed WebSocket smoke test to use native browser `WebSocket` API instead of Node-only `ws` package; injected smoke app key via Karma `client` config since `process.env` is unavailable in browser context

## Verified CI Runs
- [.NET SDK](https://github.com/ops-ai/Toggly.FeatureManagement/actions/runs/22382618528) ✅
- [JavaScript/TypeScript SDKs](https://github.com/ops-ai/Toggly.FeatureManagement/actions/runs/22383183925) ✅
- [Next.js SDKs](https://github.com/ops-ai/Toggly.FeatureManagement/actions/runs/22382619438) ✅
- [Nuxt SDKs](https://github.com/ops-ai/Toggly.FeatureManagement/actions/runs/22382619989) ✅
- [Remix SDKs](https://github.com/ops-ai/Toggly.FeatureManagement/actions/runs/22382992118) ✅
- [React Native SDKs](https://github.com/ops-ai/Toggly.FeatureManagement/actions/runs/22382992597) ✅
- [Rust SDKs](https://github.com/ops-ai/Toggly.FeatureManagement/actions/runs/22382991562) ✅

## Test plan
- [x] All 7 CI workflows pass
- [x] Smoke tests show as **skipped/pending** when env vars are missing
- [x] Smoke tests execute and pass when env vars are configured (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)